### PR TITLE
Prevent undefined behavior

### DIFF
--- a/c_src/xor_filter_nif.c
+++ b/c_src/xor_filter_nif.c
@@ -240,6 +240,7 @@ exor_initialize_empty_filter_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
 
    filter->bitmap = ewah_new();
    filter->size = 0;
+   filter->buffer = NULL;
 
    ERL_NIF_TERM res = enif_make_resource(env, filter);
    // release this resource now its owned by Erlang

--- a/priv/.gitignore
+++ b/priv/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
If an `exor_t` is created but never finalized, it triggers UB when garbage is collected. The problem is that the resource destructor frees `buffer`, a value that was never initialized. Sometimes `buffer` may be zero by chance, in [which case] the destructor does not attempt to free it. But if those uninitialized bytes <sup>[1](#f1)</sup> are anything else, the destructor will attempt to free an invalid address and likely segfault. Regardless, this is all UB, segfault or not, and the fix is to initialize the memory.


To trigger the original bug:

```erlang
   Filter0 = xor16:new_empty(),
   % xor16:finalize() is not called
   % Filter0 gets GCd
   % segfault
```

I hope you don't mind, but I added a `.gitignore` to this PR. Running `git bisect` without ignoring `priv/` was painful.

Closes #17 


[which case]: https://github.com/mpope9/exor_filter/blob/master/c_src/xor_filter_nif.c#L58-L61
<a name="f1">1</a>: A quick search didn't confirm it, but I'm fairly confident that `enif_alloc_resouce` doesn't guarantee the contents of the returned allocation.
