### PR TITLE
Fix non-deterministic to_bin

### DIFF
--- a/test/exor_filter_test.erl
+++ b/test/exor_filter_test.erl
@@ -197,7 +197,10 @@ xor8_serialization() ->
    ?assertEqual(false, xor8:contain(BinFilter, "test4")),
    Filter2 = xor8:from_bin(BinFilter),
    ?assertEqual(true, xor8:contain(Filter2, "test1")),
-   ?assertEqual(false, xor8:contain(Filter2, "test4")).
+   ?assertEqual(false, xor8:contain(Filter2, "test4")),
+   Filter3 = xor8:new(["test1", "test2", "test3"]),
+   BinFilter2 = xor8:to_bin(Filter3),
+   ?assertEqual(BinFilter, BinFilter2).
 
 xor8_incremental_builder() ->
    Filter0 = xor8:new_empty(),
@@ -403,7 +406,10 @@ xor16_serialization() ->
    ?assertEqual(false, xor16:contain(BinFilter, "test4")),
    Filter2 = xor16:from_bin(BinFilter),
    ?assertEqual(true, xor16:contain(Filter2, "test1")),
-   ?assertEqual(false, xor16:contain(Filter2, "test4")).
+   ?assertEqual(false, xor16:contain(Filter2, "test4")),
+   Filter3 = xor16:new(["test1", "test2", "test3"]),
+   BinFilter2 = xor16:to_bin(Filter3),
+   ?assertEqual(BinFilter, BinFilter2).
 
 xor16_incremental_builder() ->
    Filter0 = xor16:new_empty(),


### PR DESCRIPTION
Calling to_bin on identical filters returns non-equal binaries. It _appears_ to be related to the use of uninitialized memory in the xorfilter library itself. Because we're already replacing its use of malloc with enif_alloc, let's override it to use a custom function that wraps enif_alloc with memset.

Curiously, xor8 doesn’t appear to be affected. 

## Example code

```erlang
A = lists:foldl(fun(_, Acc) -> [crypto:strong_rand_bytes(16) | Acc] end,[],lists:seq(1, 10)),
{Filter1, _} = xor16:new(A, default_hash),
{BinFilter1, _} = xor16:to_bin({Filter1, default_hash}),
{Filter2, _} = xor16:new(A, default_hash),
{BinFilter2, _} = xor16:to_bin({Filter2, default_hash}),
```

Current binary contents:

```
7> rp(BinFilter1).
<<193,92,2,137,236,45,10,145,14,0,0,0,0,0,0,0,0,0,160,201,
  139,127,150,146,64,142,160,201,139,127,0,0,0,0,0,0,0,0,
  0,0,86,102,0,0,0,0,187,230,3,0,0,0,112,108,3,0,0,0,191,
  125,0,0,0,0,18,203,25,56,194,0,195,0,226,0,140,236,6,1,
  4,0,226,52,11,0,12,0,14,0,196,31,177,132,21,0,23,0,24,0,
  27,0>>
ok
8> rp(BinFilter2).
<<193,92,2,137,236,45,10,145,14,0,0,0,0,0,0,0,0,0,160,201,
  139,127,214,144,0,0,0,0,0,0,0,0,64,142,160,201,139,127,
  0,0,88,102,0,0,0,0,187,230,1,0,0,0,8,108,3,0,0,0,179,
  125,0,0,0,0,30,203,12,56,130,2,105,116,1,0,204,98,0,0,0,
  0,162,186,0,0,0,0,0,0,196,31,177,132,0,0,0,0,0,0,0,0>>
ok
```

This patch:

```
7> rp(BinFilter1).
<<193,92,2,137,236,45,10,145,14,0,0,0,0,0,0,0,142,156,0,0,
  223,235,45,151,0,0,0,0,0,0,0,0,0,0,98,50,114,214,246,
  176,130,223,0,0,0,0,126,89,18,6,0,0,223,173,0,0,0,0,0,0,
  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
  0,0,0,0,0,0,0,0,0,0,0,0>>
ok
8> rp(BinFilter2).
<<193,92,2,137,236,45,10,145,14,0,0,0,0,0,0,0,142,156,0,0,
  223,235,45,151,0,0,0,0,0,0,0,0,0,0,98,50,114,214,246,
  176,130,223,0,0,0,0,126,89,18,6,0,0,223,173,0,0,0,0,0,0,
  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
  0,0,0,0,0,0,0,0,0,0,0,0>>
ok
```